### PR TITLE
Add initial Solax installer settings integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @404GamerNotFound

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # ha-solax-installateur-settings
 
+Custom Home Assistant integration to manage installer settings on Solax inverters.
+
+## Installation
+
+Copy the `custom_components/solax_installateur_settings` folder to your Home Assistant `custom_components` directory or install via HACS.
+
+## Configuration
+
+Use the Home Assistant UI to add the **Solax Installer Settings** integration and provide the inverter host and installer password.
+
+## Services
+
+The integration exposes a service to change an installer parameter:
+
+```yaml
+service: solax_installateur_settings.set_installer_setting
+data:
+  setting: feed_in_limit
+  value: 50
+```
+
+The underlying HTTP API may differ between inverter models; adjust `api.py` if needed.
+
+## Implementation
+
+Communication with the inverter is handled by the internal `SolaxInstallerClient` defined in `custom_components/solax_installateur_settings/api.py`.

--- a/custom_components/solax_installateur_settings/__init__.py
+++ b/custom_components/solax_installateur_settings/__init__.py
@@ -1,0 +1,35 @@
+"""Home Assistant component to manage Solax inverter installer settings."""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, ServiceCall
+
+from .api import SolaxInstallerClient
+from .const import CONF_HOST, CONF_PASSWORD, DOMAIN
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Solax installer integration from a config entry."""
+    host: str = entry.data[CONF_HOST]
+    password: str = entry.data[CONF_PASSWORD]
+
+    client = SolaxInstallerClient(hass, host, password)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = client
+
+    async def async_set_installer_setting(call: ServiceCall) -> None:
+        await client.async_set_parameter(call.data["setting"], call.data["value"])
+
+    hass.services.async_register(
+        DOMAIN,
+        "set_installer_setting",
+        async_set_installer_setting,
+    )
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    hass.services.async_remove(DOMAIN, "set_installer_setting")
+    hass.data[DOMAIN].pop(entry.entry_id)
+    return True

--- a/custom_components/solax_installateur_settings/api.py
+++ b/custom_components/solax_installateur_settings/api.py
@@ -1,0 +1,22 @@
+"""Client for interacting with Solax inverter installer settings."""
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+
+class SolaxInstallerClient:
+    """Simple HTTP client for Solax installer settings."""
+
+    def __init__(self, hass: HomeAssistant, host: str, password: str) -> None:
+        """Initialize client with Home Assistant session."""
+        self._session = async_get_clientsession(hass)
+        self._host = host
+        self._password = password
+
+    async def async_set_parameter(self, key: str, value: str) -> dict:
+        """Set a parameter on the inverter via its HTTP API."""
+        url = f"http://{self._host}/api/installer/set"
+        params = {"pwd": self._password, "key": key, "value": value}
+        async with self._session.get(url, params=params) as resp:
+            resp.raise_for_status()
+            return await resp.json()

--- a/custom_components/solax_installateur_settings/config_flow.py
+++ b/custom_components/solax_installateur_settings/config_flow.py
@@ -1,0 +1,22 @@
+"""Config flow for Solax installer integration."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+from homeassistant import config_entries
+
+from .const import CONF_HOST, CONF_PASSWORD, DOMAIN
+
+DATA_SCHEMA = vol.Schema({
+    vol.Required(CONF_HOST): str,
+    vol.Required(CONF_PASSWORD): str,
+})
+
+
+class SolaxInstallerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for the integration."""
+
+    async def async_step_user(self, user_input=None):
+        if user_input is not None:
+            return self.async_create_entry(title="Solax Installer", data=user_input)
+        return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)

--- a/custom_components/solax_installateur_settings/const.py
+++ b/custom_components/solax_installateur_settings/const.py
@@ -1,0 +1,3 @@
+DOMAIN = "solax_installateur_settings"
+CONF_HOST = "host"
+CONF_PASSWORD = "password"

--- a/custom_components/solax_installateur_settings/manifest.json
+++ b/custom_components/solax_installateur_settings/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "solax_installateur_settings",
+  "name": "Solax Installer Settings",
+  "version": "0.1.0",
+  "documentation": "https://github.com/404GamerNotFound/ha-solax-installateur-settings",
+  "requirements": [],
+  "codeowners": ["@404GamerNotFound"],
+  "config_flow": true
+}

--- a/custom_components/solax_installateur_settings/services.yaml
+++ b/custom_components/solax_installateur_settings/services.yaml
@@ -1,0 +1,9 @@
+set_installer_setting:
+  description: Set an installer setting on the Solax inverter.
+  fields:
+    setting:
+      description: Key of the setting to modify.
+      example: feed_in_limit
+    value:
+      description: Value to apply.
+      example: 50


### PR DESCRIPTION
## Summary
- create Solax installer settings Home Assistant integration skeleton
- allow service to update inverter installer parameters via HTTP API
- document installation and usage
- designate @404GamerNotFound as codeowner
- link manifest documentation to repository README and clarify SolaxInstallerClient usage

## Testing
- `python -m py_compile custom_components/solax_installateur_settings/*.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68ba7759bf048327be60d647e9e85743