### PR TITLE
Add installer options flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Copy the `custom_components/solax_installateur_settings` folder to your Home Ass
 
 Use the Home Assistant UI to add the **Solax Installer Settings** integration and provide the inverter host and installer password.
 
+After installation, open the integration options to adjust the host or password and to send installer parameters via a simple form. Enter the setting name and value to apply changes directly to the inverter.
+
 ## Services
 
 The integration exposes a service to change an installer parameter:

--- a/custom_components/solax_installateur_settings/__init__.py
+++ b/custom_components/solax_installateur_settings/__init__.py
@@ -6,19 +6,25 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
 
 from .api import SolaxInstallerClient
-from .const import CONF_HOST, CONF_PASSWORD, DOMAIN
+from .const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_SETTING,
+    CONF_VALUE,
+    DOMAIN,
+)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Solax installer integration from a config entry."""
-    host: str = entry.data[CONF_HOST]
-    password: str = entry.data[CONF_PASSWORD]
+    host: str = entry.options.get(CONF_HOST, entry.data[CONF_HOST])
+    password: str = entry.options.get(CONF_PASSWORD, entry.data[CONF_PASSWORD])
 
     client = SolaxInstallerClient(hass, host, password)
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = client
 
     async def async_set_installer_setting(call: ServiceCall) -> None:
-        await client.async_set_parameter(call.data["setting"], call.data["value"])
+        await client.async_set_parameter(call.data[CONF_SETTING], call.data[CONF_VALUE])
 
     hass.services.async_register(
         DOMAIN,

--- a/custom_components/solax_installateur_settings/config_flow.py
+++ b/custom_components/solax_installateur_settings/config_flow.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.core import callback
 
-from .const import CONF_HOST, CONF_PASSWORD, DOMAIN
+from .const import CONF_HOST, CONF_PASSWORD, CONF_SETTING, CONF_VALUE, DOMAIN
 
 DATA_SCHEMA = vol.Schema({
     vol.Required(CONF_HOST): str,
@@ -20,3 +21,47 @@ class SolaxInstallerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             return self.async_create_entry(title="Solax Installer", data=user_input)
         return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        return SolaxInstallerOptionsFlow(config_entry)
+
+
+class SolaxInstallerOptionsFlow(config_entries.OptionsFlow):
+    """Options flow to change settings after setup."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        if user_input is not None:
+            setting = user_input.pop(CONF_SETTING, None)
+            value = user_input.pop(CONF_VALUE, None)
+            if setting and value:
+                client = self.hass.data[DOMAIN][self.config_entry.entry_id]
+                await client.async_set_parameter(setting, value)
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_HOST,
+                        default=self.config_entry.options.get(
+                            CONF_HOST, self.config_entry.data[CONF_HOST]
+                        ),
+                    ): str,
+                    vol.Required(
+                        CONF_PASSWORD,
+                        default=self.config_entry.options.get(
+                            CONF_PASSWORD, self.config_entry.data[CONF_PASSWORD]
+                        ),
+                    ): str,
+                    vol.Optional(CONF_SETTING): str,
+                    vol.Optional(CONF_VALUE): str,
+                }
+            ),
+        )

--- a/custom_components/solax_installateur_settings/const.py
+++ b/custom_components/solax_installateur_settings/const.py
@@ -1,3 +1,5 @@
 DOMAIN = "solax_installateur_settings"
 CONF_HOST = "host"
 CONF_PASSWORD = "password"
+CONF_SETTING = "setting"
+CONF_VALUE = "value"


### PR DESCRIPTION
## Summary
- allow adjusting inverter settings and credentials through an options flow
- store new constants for setting/value fields
- document how to change parameters from the integration options

## Testing
- `flake8 custom_components/solax_installateur_settings` *(fails: command not found)*
- `pytest`
- `python -m py_compile custom_components/solax_installateur_settings/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba7ace53848327ac91be82f714c3f3