### PR TITLE
Expose and edit Solax inverter settings

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,18 @@
+name: Validate
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Hassfest validation
+        uses: home-assistant/actions/hassfest@master
+      - name: HACS validation
+        uses: hacs/action@main
+        with:
+          category: integration

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Custom Home Assistant integration to manage installer settings on SolaX inverter
 
 1. In Home Assistant **Einstellungen → Geräte & Dienste → Integration hinzufügen** wählen.
 2. `Solax Installer Settings` auswählen und die IP-Adresse/den Hostnamen sowie das Installateur-Passwort des Wechselrichters eingeben.
-3. Nach der Einrichtung kann über **Konfigurieren** in der Integration der Host oder das Passwort angepasst werden. Zusätzlich lässt sich dort über ein Formular sofort ein Parameter setzen (Schlüssel und Wert angeben).
+3. Nach der Einrichtung kann über **Konfigurieren** in der Integration der Host oder das Passwort angepasst werden. Die verfügbaren Installateur-Parameter werden direkt vom Wechselrichter geladen und in einer Auswahlliste inklusive des aktuellen Wertes angezeigt, sodass Einstellungen geändert werden können, ohne den Schlüssel zu kennen.
 
 ## Services
 
-Die Integration stellt einen Dienst bereit, um Installateur-Parameter zu setzen:
+Die Integration stellt Dienste bereit, um Installateur-Parameter abzurufen und zu setzen:
 
 ```yaml
 service: solax_installateur_settings.set_installer_setting
@@ -39,7 +39,13 @@ data:
   # host: 192.168.1.100  # optional, notwendig bei mehreren Wechselrichtern
 ```
 
-Wenn mehrere Wechselrichter eingebunden sind, muss das Feld `host` gesetzt werden, damit der richtige Client ausgewählt wird.
+```yaml
+service: solax_installateur_settings.get_installer_settings
+data:
+  # host: 192.168.1.100  # optional, notwendig bei mehreren Wechselrichtern
+```
+
+Beide Dienste unterstützen mehrere Wechselrichter; in diesem Fall muss das Feld `host` gesetzt werden, damit der richtige Client ausgewählt wird.
 
 ## Implementation
 

--- a/custom_components/solax_installateur_settings/api.py
+++ b/custom_components/solax_installateur_settings/api.py
@@ -25,3 +25,11 @@ class SolaxInstallerClient:
         async with self._session.get(url, params=params) as resp:
             resp.raise_for_status()
             return await resp.json()
+
+    async def async_get_all_settings(self) -> dict:
+        """Return all installer settings from the inverter."""
+        url = f"http://{self._host}/api/installer/getall"
+        params = {"pwd": self._password}
+        async with self._session.get(url, params=params) as resp:
+            resp.raise_for_status()
+            return await resp.json()

--- a/custom_components/solax_installateur_settings/config_flow.py
+++ b/custom_components/solax_installateur_settings/config_flow.py
@@ -36,13 +36,16 @@ class SolaxInstallerOptionsFlow(config_entries.OptionsFlow):
         self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
+        client = self.hass.data[DOMAIN][self.config_entry.entry_id]
         if user_input is not None:
             setting = user_input.pop(CONF_SETTING, None)
             value = user_input.pop(CONF_VALUE, None)
             if setting and value:
-                client = self.hass.data[DOMAIN][self.config_entry.entry_id]
                 await client.async_set_parameter(setting, value)
             return self.async_create_entry(title="", data=user_input)
+
+        settings = await client.async_get_all_settings()
+        options = {f"{key} ({value})": key for key, value in settings.items()}
 
         return self.async_show_form(
             step_id="init",
@@ -60,7 +63,7 @@ class SolaxInstallerOptionsFlow(config_entries.OptionsFlow):
                             CONF_PASSWORD, self.config_entry.data[CONF_PASSWORD]
                         ),
                     ): str,
-                    vol.Optional(CONF_SETTING): str,
+                    vol.Optional(CONF_SETTING): vol.In(options),
                     vol.Optional(CONF_VALUE): str,
                 }
             ),

--- a/custom_components/solax_installateur_settings/manifest.json
+++ b/custom_components/solax_installateur_settings/manifest.json
@@ -1,7 +1,6 @@
 {
   "domain": "solax_installateur_settings",
   "name": "Solax Installer Settings",
-  "brand": "Solax",
   "codeowners": ["@404GamerNotFound"],
   "config_flow": true,
   "documentation": "https://github.com/404GamerNotFound/ha-solax-installateur-settings",

--- a/custom_components/solax_installateur_settings/manifest.json
+++ b/custom_components/solax_installateur_settings/manifest.json
@@ -5,6 +5,7 @@
   "config_flow": true,
   "documentation": "https://github.com/404GamerNotFound/ha-solax-installateur-settings",
   "iot_class": "local_polling",
+  "issue_tracker": "https://github.com/404GamerNotFound/ha-solax-installateur-settings/issues",
   "requirements": [],
   "version": "0.1.0"
 }

--- a/custom_components/solax_installateur_settings/manifest.json
+++ b/custom_components/solax_installateur_settings/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "solax_installateur_settings",
   "name": "Solax Installer Settings",
+  "brand": "Solax",
   "codeowners": ["@404GamerNotFound"],
   "config_flow": true,
   "documentation": "https://github.com/404GamerNotFound/ha-solax-installateur-settings",

--- a/custom_components/solax_installateur_settings/manifest.json
+++ b/custom_components/solax_installateur_settings/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "solax_installateur_settings",
   "name": "Solax Installer Settings",
+  "brand": "Solax",
   "version": "0.1.0",
   "documentation": "https://github.com/404GamerNotFound/ha-solax-installateur-settings",
   "requirements": [],

--- a/custom_components/solax_installateur_settings/manifest.json
+++ b/custom_components/solax_installateur_settings/manifest.json
@@ -1,10 +1,10 @@
 {
   "domain": "solax_installateur_settings",
   "name": "Solax Installer Settings",
-  "brand": "Solax",
   "version": "0.1.0",
   "documentation": "https://github.com/404GamerNotFound/ha-solax-installateur-settings",
   "requirements": [],
   "codeowners": ["@404GamerNotFound"],
-  "config_flow": true
+  "config_flow": true,
+  "iot_class": "local_polling"
 }

--- a/custom_components/solax_installateur_settings/manifest.json
+++ b/custom_components/solax_installateur_settings/manifest.json
@@ -1,10 +1,10 @@
 {
   "domain": "solax_installateur_settings",
   "name": "Solax Installer Settings",
-  "version": "0.1.0",
-  "documentation": "https://github.com/404GamerNotFound/ha-solax-installateur-settings",
-  "requirements": [],
   "codeowners": ["@404GamerNotFound"],
   "config_flow": true,
-  "iot_class": "local_polling"
+  "documentation": "https://github.com/404GamerNotFound/ha-solax-installateur-settings",
+  "iot_class": "local_polling",
+  "requirements": [],
+  "version": "0.1.0"
 }

--- a/custom_components/solax_installateur_settings/services.yaml
+++ b/custom_components/solax_installateur_settings/services.yaml
@@ -10,3 +10,10 @@ set_installer_setting:
     host:
       description: IP address or hostname of the inverter. Required when multiple inverters are configured.
       example: 192.168.1.100
+
+get_installer_settings:
+  description: Retrieve all installer settings from the Solax inverter.
+  fields:
+    host:
+      description: IP address or hostname of the inverter. Required when multiple inverters are configured.
+      example: 192.168.1.100

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,7 @@
+{
+  "name": "Solax Installer Settings",
+  "content_in_root": false,
+  "render_readme": true,
+  "domains": ["solax_installateur_settings"],
+  "brand": "Solax"
+}

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,5 @@
 {
   "name": "Solax Installer Settings",
   "content_in_root": false,
-  "render_readme": true,
-  "domains": ["solax_installateur_settings"],
-  "brand": "Solax"
+  "render_readme": true
 }

--- a/tests/test_hacs.py
+++ b/tests/test_hacs.py
@@ -4,15 +4,19 @@ from pathlib import Path
 DOMAIN = "solax_installateur_settings"
 
 
-def test_manifest_has_iot_class():
+def test_manifest_fields():
     manifest_path = Path(__file__).resolve().parent.parent / "custom_components" / DOMAIN / "manifest.json"
     manifest = json.loads(manifest_path.read_text())
     assert manifest.get("iot_class") == "local_polling"
+    assert (
+        manifest.get("issue_tracker")
+        == "https://github.com/404GamerNotFound/ha-solax-installateur-settings/issues"
+    )
 
 
 def test_hacs_file():
     hacs_path = Path(__file__).resolve().parent.parent / "hacs.json"
     hacs = json.loads(hacs_path.read_text())
     assert hacs.get("name") == "Solax Installer Settings"
-    assert DOMAIN in hacs.get("domains", [])
-    assert hacs.get("brand") == "Solax"
+    assert hacs.get("render_readme") is True
+    assert hacs.get("content_in_root") is False

--- a/tests/test_hacs.py
+++ b/tests/test_hacs.py
@@ -4,10 +4,10 @@ from pathlib import Path
 DOMAIN = "solax_installateur_settings"
 
 
-def test_manifest_brand():
+def test_manifest_has_iot_class():
     manifest_path = Path(__file__).resolve().parent.parent / "custom_components" / DOMAIN / "manifest.json"
     manifest = json.loads(manifest_path.read_text())
-    assert manifest.get("brand") == "Solax"
+    assert manifest.get("iot_class") == "local_polling"
 
 
 def test_hacs_file():
@@ -15,3 +15,4 @@ def test_hacs_file():
     hacs = json.loads(hacs_path.read_text())
     assert hacs.get("name") == "Solax Installer Settings"
     assert DOMAIN in hacs.get("domains", [])
+    assert hacs.get("brand") == "Solax"

--- a/tests/test_hacs.py
+++ b/tests/test_hacs.py
@@ -7,7 +7,6 @@ DOMAIN = "solax_installateur_settings"
 def test_manifest_fields():
     manifest_path = Path(__file__).resolve().parent.parent / "custom_components" / DOMAIN / "manifest.json"
     manifest = json.loads(manifest_path.read_text())
-    assert manifest.get("brand") == "Solax"
     assert manifest.get("iot_class") == "local_polling"
     assert (
         manifest.get("issue_tracker")

--- a/tests/test_hacs.py
+++ b/tests/test_hacs.py
@@ -1,0 +1,17 @@
+import json
+from pathlib import Path
+
+DOMAIN = "solax_installateur_settings"
+
+
+def test_manifest_brand():
+    manifest_path = Path(__file__).resolve().parent.parent / "custom_components" / DOMAIN / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest.get("brand") == "Solax"
+
+
+def test_hacs_file():
+    hacs_path = Path(__file__).resolve().parent.parent / "hacs.json"
+    hacs = json.loads(hacs_path.read_text())
+    assert hacs.get("name") == "Solax Installer Settings"
+    assert DOMAIN in hacs.get("domains", [])

--- a/tests/test_hacs.py
+++ b/tests/test_hacs.py
@@ -7,6 +7,7 @@ DOMAIN = "solax_installateur_settings"
 def test_manifest_fields():
     manifest_path = Path(__file__).resolve().parent.parent / "custom_components" / DOMAIN / "manifest.json"
     manifest = json.loads(manifest_path.read_text())
+    assert manifest.get("brand") == "Solax"
     assert manifest.get("iot_class") == "local_polling"
     assert (
         manifest.get("issue_tracker")


### PR DESCRIPTION
## Summary
- Add API helper to retrieve all installer settings
- Show current settings in options flow for easy adjustment
- Provide `get_installer_settings` service and document usage
- Declare Solax brand in manifest and add HACS metadata and tests

## Testing
- `python -m py_compile custom_components/solax_installateur_settings/api.py custom_components/solax_installateur_settings/__init__.py custom_components/solax_installateur_settings/config_flow.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd1e62bf608327b0e79f51fe0fc056