### PR TITLE
Use integration-provided setting names

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -25,7 +25,7 @@ Benutzerdefinierte Home Assistant-Integration zum Verwalten von Installateur-Ein
 
 1. In Home Assistant **Einstellungen → Geräte & Dienste → Integration hinzufügen** wählen.
 2. `Solax Installer Settings` auswählen und die IP-Adresse/den Hostnamen sowie das Installateur-Passwort des Wechselrichters eingeben.
-3. Nach der Einrichtung kann über **Konfigurieren** in der Integration der Host oder das Passwort angepasst werden. Die verfügbaren Installateur-Parameter werden direkt vom Wechselrichter geladen und in einer Auswahlliste inklusive des aktuellen Wertes angezeigt, sodass Einstellungen geändert werden können, ohne den Schlüssel zu kennen. Standardmäßig läuft die Integration im *Nur-Lesen*-Modus, um unbeabsichtigte Änderungen zu vermeiden. Dieser Modus kann in den Integrationsoptionen deaktiviert werden, um Änderungen zu ermöglichen.
+3. Nach der Einrichtung kann über **Konfigurieren** in der Integration der Host oder das Passwort angepasst werden. Die verfügbaren Installateur-Parameter werden direkt vom Wechselrichter geladen und in einer Auswahlliste mit lesbaren Namen und dem aktuellen Wert angezeigt, sodass Einstellungen geändert werden können, ohne den Schlüssel zu kennen. Standardmäßig läuft die Integration im *Nur-Lesen*-Modus, um unbeabsichtigte Änderungen zu vermeiden. Dieser Modus kann in den Integrationsoptionen deaktiviert werden, um Änderungen zu ermöglichen.
 
 ## Dienste
 
@@ -34,7 +34,7 @@ Die Integration stellt Dienste bereit, um Installateur-Parameter abzurufen und z
 ```yaml
 service: solax_installateur_settings.set_installer_setting
 data:
-  setting: feed_in_limit
+  setting: Feed-in Limit
   value: 50
   confirm: true
   # host: 192.168.1.100  # optional, notwendig bei mehreren Wechselrichtern

--- a/README.es.md
+++ b/README.es.md
@@ -25,7 +25,7 @@ Integración personalizada de Home Assistant para gestionar los ajustes de insta
 
 1. En Home Assistant ve a **Configuración → Dispositivos y Servicios → Agregar integración**.
 2. Selecciona `Solax Installer Settings` e introduce la dirección IP/nombre de host y la contraseña de instalador del inversor.
-3. Tras la configuración, el host o la contraseña se pueden actualizar mediante **Configurar** en la integración. Los parámetros de instalador disponibles se cargan directamente desde el inversor y se muestran en una lista desplegable con el valor actual, lo que permite cambiar ajustes sin conocer la clave. De forma predeterminada la integración funciona en modo *solo lectura* para evitar cambios accidentales; puede desactivarse en las opciones de la integración para permitir modificaciones.
+3. Tras la configuración, el host o la contraseña se pueden actualizar mediante **Configurar** en la integración. Los parámetros de instalador disponibles se cargan directamente desde el inversor y se muestran en una lista desplegable con nombres legibles y el valor actual, lo que permite cambiar ajustes sin conocer la clave. De forma predeterminada la integración funciona en modo *solo lectura* para evitar cambios accidentales; puede desactivarse en las opciones de la integración para permitir modificaciones.
 
 ## Servicios
 
@@ -34,7 +34,7 @@ La integración proporciona servicios para obtener y establecer parámetros de i
 ```yaml
 service: solax_installateur_settings.set_installer_setting
 data:
-  setting: feed_in_limit
+  setting: Feed-in Limit
   value: 50
   confirm: true
   # host: 192.168.1.100  # opcional, necesario cuando se usan varios inversores

--- a/README.fr.md
+++ b/README.fr.md
@@ -25,7 +25,7 @@ Intégration personnalisée pour Home Assistant permettant de gérer les paramè
 
 1. Dans Home Assistant, va à **Paramètres → Appareils et services → Ajouter une intégration**.
 2. Sélectionne `Solax Installer Settings` et saisis l’adresse IP/le nom d’hôte ainsi que le mot de passe installateur de l’onduleur.
-3. Après la configuration, l’hôte ou le mot de passe peuvent être mis à jour via **Configurer** dans l’intégration. Les paramètres installateur disponibles sont chargés directement depuis l’onduleur et affichés dans une liste déroulante avec la valeur actuelle, permettant de modifier les réglages sans connaître la clé. Par défaut, l’intégration fonctionne en mode *lecture seule* pour éviter les modifications accidentelles ; ce mode peut être désactivé dans les options de l’intégration pour autoriser les changements.
+3. Après la configuration, l’hôte ou le mot de passe peuvent être mis à jour via **Configurer** dans l’intégration. Les paramètres installateur disponibles sont chargés directement depuis l’onduleur et affichés dans une liste déroulante avec des noms lisibles et la valeur actuelle, permettant de modifier les réglages sans connaître la clé. Par défaut, l’intégration fonctionne en mode *lecture seule* pour éviter les modifications accidentelles ; ce mode peut être désactivé dans les options de l’intégration pour autoriser les changements.
 
 ## Services
 
@@ -34,7 +34,7 @@ L’intégration fournit des services pour récupérer et définir des paramètr
 ```yaml
 service: solax_installateur_settings.set_installer_setting
 data:
-  setting: feed_in_limit
+  setting: Feed-in Limit
   value: 50
   confirm: true
   # host: 192.168.1.100  # optionnel, requis lors de l’utilisation de plusieurs onduleurs

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Custom Home Assistant integration to manage installer settings on SolaX inverter
 
 1. In Home Assistant go to **Settings → Devices & Services → Add Integration**.
 2. Select `Solax Installer Settings` and enter the IP address/hostname and the inverter's installer password.
-3. After setup, the host or password can be updated via **Configure** in the integration. The available installer parameters are loaded directly from the inverter and shown in a dropdown with the current value, allowing changes without knowing the key. By default the integration runs in *view-only* mode to avoid accidental changes. Disable this option in the integration settings to allow modifications.
+3. After setup, the host or password can be updated via **Configure** in the integration. The available installer parameters are loaded directly from the inverter and shown in a dropdown with the current value, using human-friendly names so the raw keys don't need to be entered manually. By default the integration runs in *view-only* mode to avoid accidental changes. Disable this option in the integration settings to allow modifications.
 
 ## Services
 
@@ -36,7 +36,7 @@ The integration provides services to retrieve and set installer parameters:
 ```yaml
 service: solax_installateur_settings.set_installer_setting
 data:
-  setting: feed_in_limit
+  setting: Feed-in Limit
   value: 50
   confirm: true
   # host: 192.168.1.100  # optional, required when using multiple inverters

--- a/custom_components/solax_installateur_settings/__init__.py
+++ b/custom_components/solax_installateur_settings/__init__.py
@@ -14,6 +14,7 @@ from .const import (
     CONF_VIEW_ONLY,
     CONF_CONFIRM,
     DOMAIN,
+    SETTING_NAMES,
 )
 
 
@@ -48,9 +49,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             if not call.data.get(CONF_CONFIRM):
                 raise ValueError("Confirmation required to modify settings")
 
-            await target_client.async_set_parameter(
-                call.data[CONF_SETTING], call.data[CONF_VALUE]
-            )
+            setting = call.data[CONF_SETTING]
+            reverse = {v: k for k, v in SETTING_NAMES.items()}
+            key = reverse.get(setting, setting)
+            await target_client.async_set_parameter(key, call.data[CONF_VALUE])
 
         hass.services.async_register(
             DOMAIN, "set_installer_setting", async_set_installer_setting

--- a/custom_components/solax_installateur_settings/config_flow.py
+++ b/custom_components/solax_installateur_settings/config_flow.py
@@ -16,6 +16,7 @@ from .const import (
     CONF_VALUE,
     CONF_VIEW_ONLY,
     DOMAIN,
+    SETTING_NAMES,
 )
 
 DATA_SCHEMA = vol.Schema({
@@ -68,7 +69,10 @@ class SolaxInstallerOptionsFlow(config_entries.OptionsFlow):
             settings = await client.async_get_all_settings()
             if not isinstance(settings, dict):
                 raise ValueError
-            options = {f"{key} ({value})": key for key, value in settings.items()}
+            options = {
+                f"{SETTING_NAMES.get(key, key)} ({value})": key
+                for key, value in settings.items()
+            }
         except (ClientError, asyncio.TimeoutError, ValueError):
             errors.setdefault("base", "cannot_connect")
 

--- a/custom_components/solax_installateur_settings/const.py
+++ b/custom_components/solax_installateur_settings/const.py
@@ -5,3 +5,12 @@ CONF_SETTING = "setting"
 CONF_VALUE = "value"
 CONF_VIEW_ONLY = "view_only"
 CONF_CONFIRM = "confirm"
+
+# Mapping of inverter setting keys to human-friendly names. This allows the
+# integration to present readable labels instead of raw keys, so users don't
+# need to know or provide the internal key names themselves.
+# Only a small subset of settings is known; unknown keys fall back to the raw
+# key string.
+SETTING_NAMES = {
+    "feed_in_limit": "Feed-in Limit",
+}

--- a/custom_components/solax_installateur_settings/services.yaml
+++ b/custom_components/solax_installateur_settings/services.yaml
@@ -2,8 +2,9 @@ set_installer_setting:
   description: Set an installer setting on the Solax inverter.
   fields:
     setting:
-      description: Key of the setting to modify.
-      example: feed_in_limit
+      description: Name of the setting to modify. May be either the internal key
+        or the human-friendly name provided by the integration.
+      example: Feed-in Limit
     value:
       description: Value to apply.
       example: 50


### PR DESCRIPTION
## Summary
- show human-friendly setting names fetched by the integration
- allow services to accept friendly names instead of raw keys

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd9e62e4148327a8b54bf4fe8dba34