### PR TITLE
Support http/https schemes and ports in inverter host

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -24,7 +24,7 @@ Benutzerdefinierte Home Assistant-Integration zum Verwalten von Installateur-Ein
 ## Konfiguration
 
 1. In Home Assistant **Einstellungen → Geräte & Dienste → Integration hinzufügen** wählen.
-2. `Solax Installer Settings` auswählen und die IP-Adresse/den Hostnamen sowie das Installateur-Passwort des Wechselrichters eingeben.
+2. `Solax Installer Settings` auswählen und den Host des Wechselrichters (IP/Hostname, optional mit Port oder http/https-Schema) sowie das Installateur-Passwort eingeben.
 3. Nach der Einrichtung kann über **Konfigurieren** in der Integration der Host oder das Passwort angepasst werden. Die verfügbaren Installateur-Parameter werden direkt vom Wechselrichter geladen und in einer Auswahlliste mit lesbaren Namen und dem aktuellen Wert angezeigt, sodass Einstellungen geändert werden können, ohne den Schlüssel zu kennen. Standardmäßig läuft die Integration im *Nur-Lesen*-Modus, um unbeabsichtigte Änderungen zu vermeiden. Dieser Modus kann in den Integrationsoptionen deaktiviert werden, um Änderungen zu ermöglichen.
 
 ## Dienste
@@ -37,14 +37,14 @@ data:
   setting: Feed-in Limit
   value: 50
   confirm: true
-  # host: 192.168.1.100  # optional, notwendig bei mehreren Wechselrichtern
+  # host: 192.168.1.100  # optional, notwendig bei mehreren Wechselrichtern; Port/Scheme möglich
 ```
 `confirm: true` ist als Sicherheitsmaßnahme erforderlich; Aufrufe ohne diese Bestätigung werden abgelehnt.
 
 ```yaml
 service: solax_installateur_settings.get_installer_settings
 data:
-  # host: 192.168.1.100  # optional, notwendig bei mehreren Wechselrichtern
+  # host: 192.168.1.100  # optional, notwendig bei mehreren Wechselrichtern; Port/Scheme möglich
 ```
 
 Beide Dienste unterstützen mehrere Wechselrichter; in diesem Fall muss das Feld `host` gesetzt werden, damit der richtige Client ausgewählt wird.
@@ -52,4 +52,3 @@ Beide Dienste unterstützen mehrere Wechselrichter; in diesem Fall muss das Feld
 ## Implementierung
 
 Die Kommunikation mit dem Wechselrichter wird vom internen `SolaxInstallerClient` in `custom_components/solax_installateur_settings/api.py` übernommen. Die HTTP-API kann je nach Wechselrichtermodell variieren; bei Bedarf `api.py` anpassen.
-

--- a/README.es.md
+++ b/README.es.md
@@ -24,7 +24,7 @@ Integración personalizada de Home Assistant para gestionar los ajustes de insta
 ## Configuración
 
 1. En Home Assistant ve a **Configuración → Dispositivos y Servicios → Agregar integración**.
-2. Selecciona `Solax Installer Settings` e introduce la dirección IP/nombre de host y la contraseña de instalador del inversor.
+2. Selecciona `Solax Installer Settings` e introduce el host del inversor (IP/nombre de host, con puerto opcional o esquema http/https) y la contraseña de instalador.
 3. Tras la configuración, el host o la contraseña se pueden actualizar mediante **Configurar** en la integración. Los parámetros de instalador disponibles se cargan directamente desde el inversor y se muestran en una lista desplegable con nombres legibles y el valor actual, lo que permite cambiar ajustes sin conocer la clave. De forma predeterminada la integración funciona en modo *solo lectura* para evitar cambios accidentales; puede desactivarse en las opciones de la integración para permitir modificaciones.
 
 ## Servicios
@@ -37,14 +37,14 @@ data:
   setting: Feed-in Limit
   value: 50
   confirm: true
-  # host: 192.168.1.100  # opcional, necesario cuando se usan varios inversores
+  # host: 192.168.1.100  # opcional, necesario cuando se usan varios inversores; se admite puerto/esquema
 ```
 `confirm: true` es obligatorio como medida de seguridad; las llamadas sin él se rechazan.
 
 ```yaml
 service: solax_installateur_settings.get_installer_settings
 data:
-  # host: 192.168.1.100  # opcional, necesario cuando se usan varios inversores
+  # host: 192.168.1.100  # opcional, necesario cuando se usan varios inversores; se admite puerto/esquema
 ```
 
 Ambos servicios admiten múltiples inversores; en ese caso debe establecerse el campo `host` para seleccionar el cliente correcto.
@@ -52,4 +52,3 @@ Ambos servicios admiten múltiples inversores; en ese caso debe establecerse el 
 ## Implementación
 
 La comunicación con el inversor se gestiona mediante el `SolaxInstallerClient` interno definido en `custom_components/solax_installateur_settings/api.py`. La API HTTP puede variar según el modelo de inversor; ajusta `api.py` si es necesario.
-

--- a/README.fr.md
+++ b/README.fr.md
@@ -24,7 +24,7 @@ Intégration personnalisée pour Home Assistant permettant de gérer les paramè
 ## Configuration
 
 1. Dans Home Assistant, va à **Paramètres → Appareils et services → Ajouter une intégration**.
-2. Sélectionne `Solax Installer Settings` et saisis l’adresse IP/le nom d’hôte ainsi que le mot de passe installateur de l’onduleur.
+2. Sélectionne `Solax Installer Settings` et saisis l’hôte de l’onduleur (IP/nom d’hôte, avec port facultatif ou schéma http/https) ainsi que le mot de passe installateur.
 3. Après la configuration, l’hôte ou le mot de passe peuvent être mis à jour via **Configurer** dans l’intégration. Les paramètres installateur disponibles sont chargés directement depuis l’onduleur et affichés dans une liste déroulante avec des noms lisibles et la valeur actuelle, permettant de modifier les réglages sans connaître la clé. Par défaut, l’intégration fonctionne en mode *lecture seule* pour éviter les modifications accidentelles ; ce mode peut être désactivé dans les options de l’intégration pour autoriser les changements.
 
 ## Services
@@ -37,14 +37,14 @@ data:
   setting: Feed-in Limit
   value: 50
   confirm: true
-  # host: 192.168.1.100  # optionnel, requis lors de l’utilisation de plusieurs onduleurs
+  # host: 192.168.1.100  # optionnel, requis lors de l’utilisation de plusieurs onduleurs ; port/schéma pris en charge
 ```
 `confirm: true` est requis à titre de mesure de sécurité ; les appels sans cette confirmation sont rejetés.
 
 ```yaml
 service: solax_installateur_settings.get_installer_settings
 data:
-  # host: 192.168.1.100  # optionnel, requis lors de l’utilisation de plusieurs onduleurs
+  # host: 192.168.1.100  # optionnel, requis lors de l’utilisation de plusieurs onduleurs ; port/schéma pris en charge
 ```
 
 Les deux services prennent en charge plusieurs onduleurs ; dans ce cas, le champ `host` doit être défini pour sélectionner le bon client.
@@ -52,4 +52,3 @@ Les deux services prennent en charge plusieurs onduleurs ; dans ce cas, le cham
 ## Implémentation
 
 La communication avec l’onduleur est gérée par le `SolaxInstallerClient` interne défini dans `custom_components/solax_installateur_settings/api.py`. L’API HTTP peut varier selon le modèle d’onduleur ; ajuste `api.py` si nécessaire.
-

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Custom Home Assistant integration to manage installer settings on SolaX inverter
 ## Configuration
 
 1. In Home Assistant go to **Settings → Devices & Services → Add Integration**.
-2. Select `Solax Installer Settings` and enter the IP address/hostname and the inverter's installer password.
+2. Select `Solax Installer Settings` and enter the inverter host (IP/hostname, with optional port or http/https scheme) and the installer password.
 3. After setup, the host or password can be updated via **Configure** in the integration. The available installer parameters are loaded directly from the inverter and shown in a dropdown with the current value, using human-friendly names so the raw keys don't need to be entered manually. By default the integration runs in *view-only* mode to avoid accidental changes. Disable this option in the integration settings to allow modifications.
 
 ## Services
@@ -39,14 +39,14 @@ data:
   setting: Feed-in Limit
   value: 50
   confirm: true
-  # host: 192.168.1.100  # optional, required when using multiple inverters
+  # host: 192.168.1.100  # optional, required when using multiple inverters; port/scheme supported
 ```
 `confirm: true` is required as a safety measure; calls without it are rejected.
 
 ```yaml
 service: solax_installateur_settings.get_installer_settings
 data:
-  # host: 192.168.1.100  # optional, required when using multiple inverters
+  # host: 192.168.1.100  # optional, required when using multiple inverters; port/scheme supported
 ```
 
 Both services support multiple inverters; in that case the `host` field must be set so the correct client is selected.
@@ -54,4 +54,3 @@ Both services support multiple inverters; in that case the `host` field must be 
 ## Implementation
 
 Communication with the inverter is handled by the internal `SolaxInstallerClient` defined in `custom_components/solax_installateur_settings/api.py`. The HTTP API may vary by inverter model; adjust `api.py` if needed.
-

--- a/custom_components/solax_installateur_settings/services.yaml
+++ b/custom_components/solax_installateur_settings/services.yaml
@@ -9,7 +9,7 @@ set_installer_setting:
       description: Value to apply.
       example: 50
     host:
-      description: IP address or hostname of the inverter. Required when multiple inverters are configured.
+      description: IP address or hostname of the inverter. Optional port and http/https scheme are supported. Required when multiple inverters are configured.
       example: 192.168.1.100
     confirm:
       description: Must be true to apply the change.
@@ -19,5 +19,5 @@ get_installer_settings:
   description: Retrieve all installer settings from the Solax inverter.
   fields:
     host:
-      description: IP address or hostname of the inverter. Required when multiple inverters are configured.
+      description: IP address or hostname of the inverter. Optional port and http/https scheme are supported. Required when multiple inverters are configured.
       example: 192.168.1.100


### PR DESCRIPTION
### Motivation
- Allow specifying the inverter host with an explicit `http`/`https` scheme or a non-standard port so API URLs are built correctly and connection errors are avoided.

### Description
- Add `urlparse` and a `_base_url` property in `custom_components/solax_installateur_settings/api.py` to detect if the provided host includes a scheme/netloc and to normalize the base API URL.
- Use `self._base_url` instead of the previous hardcoded `http://{host}` when constructing `/api/installer/getall` and `/api/installer/set` requests.
- Update documentation in `README.md`, `README.de.md`, `README.es.md`, `README.fr.md` and `custom_components/solax_installateur_settings/services.yaml` to note that host entries may include an optional port and `http`/`https` scheme.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b4f74af3483279a1700eaa0891db9)